### PR TITLE
Interrupt Read and Write return error code if error or bytes read/sen…

### DIFF
--- a/libusbhid.pas
+++ b/libusbhid.pas
@@ -142,38 +142,48 @@ end;
 
 function libusbhid_interrupt_write(var hid_device_context:libusbhid_context; out_endpoint:byte; var data_into_device{array of byte}; const data_length:byte; const timeout:dword=0):longint;
 var
-  return_code:longint;
+  return_code,transfer_result:longint;
 begin
-  return_code:=libusb_interrupt_transfer(hid_device_context.usb_device_handle,out_endpoint,@data_into_device, data_length, @Result,timeout);
+  return_code:=libusb_interrupt_transfer(hid_device_context.usb_device_handle,out_endpoint,@data_into_device, data_length, @transfer_result,timeout);
 
   if return_code < LIBUSB_SUCCESS then
   begin
+    result:=return_code;
     if return_code<>LIBUSB_ERROR_TIMEOUT then WriteLn('interrupt write to usb device failed! return code: ',return_code)
 {$ifdef DEBUG_MSG}
-		else DBG_MSG(Format('%s libusbhid_interrupt_write. TIMEOUT bytes written: %d',[FormatDateTime(TIME_FORMAT,Now()),Result]))
+   else DBG_MSG(Format('%s libusbhid_interrupt_write. TIMEOUT bytes written: %d',[FormatDateTime(TIME_FORMAT,Now()),Result]))
 {$endif}
   end
+  else 
+  begin
+    result:=transfer_result;
 {$ifdef DEBUG_MSG}
-  else DBG_MSG(Format('%s libusbhid_interrupt_write. sent: %d bytes to device ',[FormatDateTime(TIME_FORMAT,Now()),Result]));
+    DBG_MSG(Format('%s libusbhid_interrupt_write. sent: %d bytes to device ',[FormatDateTime(TIME_FORMAT,Now()),Result]));
 {$endif}
+  end;
 end;
 
 function libusbhid_interrupt_read(var hid_device_context:libusbhid_context; in_endpoint:byte; out data_from_device{array of byte}; const data_length:byte; const timeout:dword=0):longint;
 var
-  return_code:longint;
+  return_code,transfer_result:longint;
 begin
-  return_code:=libusb_interrupt_transfer(hid_device_context.usb_device_handle,in_endpoint,@data_from_device, data_length, @Result, timeout);
+  return_code:=libusb_interrupt_transfer(hid_device_context.usb_device_handle,in_endpoint,@data_from_device, data_length, @transfer_result, timeout);
 
   if return_code < LIBUSB_SUCCESS then
   begin
+    result:=return_code;
     if return_code<>LIBUSB_ERROR_TIMEOUT then WriteLn('libusbhid_interrupt_read. failed! return code: ',return_code)
 {$ifdef DEBUG_MSG}
-		else DBG_MSG(Format('%s libusbhid_interrupt_read. TIMEOUT bytes read: %d',[FormatDateTime(TIME_FORMAT,Now()),Result]))
+    else DBG_MSG(Format('%s libusbhid_interrupt_read. TIMEOUT bytes read: %d',[FormatDateTime(TIME_FORMAT,Now()),Result]))
 {$endif}
   end
+  else 
+  begin
+    result:=transfer_result;
 {$ifdef DEBUG_MSG}
-  else DBG_MSG(Format('%s libusbhid_interrupt_read. received: %d bytes from device ',[FormatDateTime(TIME_FORMAT,Now()),Result]));
+    DBG_MSG(Format('%s libusbhid_interrupt_read. received: %d bytes from device ',[FormatDateTime(TIME_FORMAT,Now()),Result]));
 {$endif}
+  end;
 end;
 
 


### PR DESCRIPTION
I noticed that lib_interupt_transfer produces a return code if anything prevents the transfer from being completed.  Since the number of bytes read or sent is irrelevent due to an error, and the error codes seem to be negative, then there is no ambiguity if we return the error if it is negative or bytes transferred if it is not negative.   That way calls to libusbhid_interrupt_write and libusbhid_interrupt_read can quckly get the return code and / or the number of bytes transferred.   Since the interrupt read is happening in a tight loop and running way faster than anything else, it's likely that this will be the fastest way to stop the read thread when the device is unplugged.  The first read that produces an error will stop the thread.

I have tested this on my test branch.  I get one negative return code during normal use... and that is if I get a timeout,  I get a -7, perhaps because I asked for 8 bytes maybe?  This is also useful information to have in my loop as if I get a -7, I don't need to bother checking the data at all since it was not read, it was just a timeout.

